### PR TITLE
Remove badness on branch repeat

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "whynot",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "homepage": "https://github.com/bwrrp/whynot.js",
   "authors": [
     "Stef Busking <stef.busking@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whynot.js",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Generic VM-based structure matching framework",
   "keywords": [
     "Language",

--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -10,8 +10,6 @@ define(
 		) {
 		'use strict';
 
-		var REPEAT_BADNESS = 1.0;
-
 		/**
 		 * Schedules Threads to run in the current or a future Generation.
 		 *
@@ -68,11 +66,6 @@ define(
 		 * @return {Thread|null} The Thread that was added, or null if no thread was added
 		 */
 		Scheduler.prototype.addThread = function(generationOffset, pc, parentThread, badness) {
-			// Prefer non-repeating threads over repeating ones
-			if (parentThread && parentThread.trace.contains(pc)) {
-				badness += REPEAT_BADNESS;
-			}
-
 			var generationForThread = getRelativeGeneration(this, generationOffset);
 
 			// Add thread to the generation

--- a/test/runner.mustache
+++ b/test/runner.mustache
@@ -16,7 +16,7 @@
 <script>
 	var files = [];
 	{{#serve_files}}
-	files.push("../{{src}}");
+	files.push("../{{& src}}");
 	{{/serve_files}}
 	require(files, function() {
 		mocha.run();

--- a/test/specs/Scheduler.tests.js
+++ b/test/specs/Scheduler.tests.js
@@ -44,13 +44,6 @@ define(
 					chai.expect(nextGenThread).to.equal(rootThread);
 					chai.expect(scheduler.getNextThread()).to.equal(null);
 				});
-
-				it('increases badness for repeating threads', function() {
-					var rootThread = scheduler.addThread(0, 0, null, 0),
-						repeatingThread = scheduler.addThread(1, 0, rootThread, 0);
-
-					chai.expect(repeatingThread.badness).to.be.above(0);
-				});
 			});
 		});
 	}


### PR DESCRIPTION
Because repeating branches are always finished, or removed because of repetition inside the same branch, the automatic badness increment is unneeded.

This badness introduces a case where a thread is merged with another thread with higher badness, causing the ordering of trace prefixes to be off. (see test case in Example.tests.js).

By removing the badness, the ordering of trace prefixes is by the time the branches arrive at a joining instruction. Because this is ordered by the badness of their respective threads, prefixes are ordened by badness.