### PR TITLE
Remove trace.head

### DIFF
--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -19,7 +19,6 @@ function mergeVisitedInstructions(
  * A Trace represents the execution history of a Thread
  */
 export default class Trace {
-	public head: number[] = [];
 	public records: any[] = [];
 	public prefixes: Trace[] = [];
 
@@ -40,7 +39,6 @@ export default class Trace {
 		precedingTrace: Trace | null,
 		generationNumber: number
 	) {
-		this.head = [pc];
 		this._programLength = programLength;
 
 		if (precedingTrace) {
@@ -108,8 +106,6 @@ export default class Trace {
 		while (trace.prefixes.length === 1) {
 			// Trace has a single prefix, combine traces
 			const prefix = trace.prefixes[0];
-			// Combine heads
-			this.head.unshift.apply(this.head, prefix.head);
 			// Combine records
 			this.records.unshift.apply(this.records, prefix.records);
 			// Adopt prefixes

--- a/test/Trace.tests.ts
+++ b/test/Trace.tests.ts
@@ -9,10 +9,6 @@ describe('Trace', () => {
 			trace = new Trace(4, PROGRAM_LENGTH, null, 0);
 		});
 
-		it('has a head', () => {
-			expect(trace.head).toEqual([4]);
-		});
-
 		it('has no records', () => {
 			expect(trace.records.length).toBe(0);
 		});
@@ -25,7 +21,6 @@ describe('Trace', () => {
 			it('does not change the trace', () => {
 				trace.compact();
 
-				expect(trace.head).toEqual([4]);
 				expect(trace.records.length).toBe(0);
 				expect(trace.prefixes.length).toBe(0);
 			});
@@ -40,24 +35,18 @@ describe('Trace', () => {
 			trace = new Trace(4, PROGRAM_LENGTH, rootTrace, 1);
 		});
 
-		it('has a head', () => {
-			expect(trace.head).toEqual([4]);
-		});
-
 		it('has no records', () => {
 			expect(trace.records.length).toBe(0);
 		});
 
 		it('has a single prefix', () => {
 			expect(trace.prefixes.length).toBe(1);
-			expect(trace.prefixes[0].head).toEqual([1]);
 		});
 
 		describe('.compact()', () => {
 			it('combines the traces', () => {
 				trace.compact();
 
-				expect(trace.head).toEqual([1, 4]);
 				expect(trace.records.length).toBe(0);
 				expect(trace.prefixes.length).toBe(0);
 			});
@@ -71,7 +60,6 @@ describe('Trace', () => {
 				it('combines the traces', () => {
 					trace.compact();
 
-					expect(trace.head).toEqual([1, 4]);
 					expect(trace.records).toEqual(['bla', 'meep']);
 					expect(trace.prefixes.length).toBe(0);
 				});
@@ -91,25 +79,17 @@ describe('Trace', () => {
 			trace.prefixes.push(otherRootTrace);
 		});
 
-		it('has a head', () => {
-			expect(trace.head).toEqual([4]);
-		});
-
 		it('has no records', () => {
 			expect(trace.records.length).toBe(0);
 		});
 
 		it('has a two prefixes', () => {
 			expect(trace.prefixes.length).toBe(2);
-			expect(trace.prefixes[0].head).toEqual([1]);
-			expect(trace.prefixes[1].head).toEqual([2]);
 		});
 
 		describe('.compact()', () => {
 			it('does not change the trace', () => {
 				trace.compact();
-
-				expect(trace.head).toEqual([4]);
 				expect(trace.records.length).toBe(0);
 				expect(trace.prefixes.length).toBe(2);
 			});

--- a/test/Trace.tests.ts
+++ b/test/Trace.tests.ts
@@ -32,11 +32,13 @@ describe('Trace', () => {
 		let trace: Trace;
 		beforeEach(() => {
 			rootTrace = new Trace(1, PROGRAM_LENGTH, null, 0);
+			rootTrace.records.push('A');
 			trace = new Trace(4, PROGRAM_LENGTH, rootTrace, 1);
+			trace.records.push('B');
 		});
 
-		it('has no records', () => {
-			expect(trace.records.length).toBe(0);
+		it('has only its own record', () => {
+			expect(trace.records.length).toBe(1);
 		});
 
 		it('has a single prefix', () => {
@@ -47,22 +49,8 @@ describe('Trace', () => {
 			it('combines the traces', () => {
 				trace.compact();
 
-				expect(trace.records.length).toBe(0);
+				expect(trace.records).toEqual(['A', 'B']);
 				expect(trace.prefixes.length).toBe(0);
-			});
-
-			describe('with records', () => {
-				beforeEach(() => {
-					rootTrace.records.push('bla');
-					trace.records.push('meep');
-				});
-
-				it('combines the traces', () => {
-					trace.compact();
-
-					expect(trace.records).toEqual(['bla', 'meep']);
-					expect(trace.prefixes.length).toBe(0);
-				});
 			});
 		});
 	});


### PR DESCRIPTION
This fixes #31 

The head property of Trace was only used in tests. So I removed the head property and rewrote the tests to use the record property.

This change will ensure that we won't allocate memory for the head.