### PR TITLE
Lazy records allocation

### DIFF
--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -19,7 +19,7 @@ function mergeVisitedInstructions(
  * A Trace represents the execution history of a Thread
  */
 export default class Trace {
-	public records: any[] = [];
+	public records: any[]|null = null;
 	public prefixes: Trace[] = [];
 
 	private _descendants: Trace[] = [];
@@ -107,7 +107,13 @@ export default class Trace {
 			// Trace has a single prefix, combine traces
 			const prefix = trace.prefixes[0];
 			// Combine records
-			this.records.unshift.apply(this.records, prefix.records);
+			if (prefix.records != null) {
+				if (this.records !== null) {
+					this.records.unshift.apply(this.records, prefix.records);
+				} else {
+					this.records = prefix.records;
+				}
+			}
 			// Adopt prefixes
 			this.prefixes = prefix.prefixes;
 			// Continue

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -19,7 +19,7 @@ function mergeVisitedInstructions(
  * A Trace represents the execution history of a Thread
  */
 export default class Trace {
-	public records: any[]|null = null;
+	public records: any[] | null = null;
 	public prefixes: Trace[] = [];
 
 	private _descendants: Trace[] = [];
@@ -111,7 +111,7 @@ export default class Trace {
 				if (this.records !== null) {
 					this.records.unshift.apply(this.records, prefix.records);
 				} else {
-					this.records = prefix.records;
+					this.records = prefix.records.concat();
 				}
 			}
 			// Adopt prefixes

--- a/src/VM.ts
+++ b/src/VM.ts
@@ -164,7 +164,11 @@ export default class VM<I, O = void> {
 						const func = instruction.func as RecordFunc<O>;
 						const record = func(instruction.data, inputIndex, options);
 						if (record !== null && record !== undefined) {
-							thread.trace.records.push(record);
+							if (thread.trace.records === null) {
+								thread.trace.records = [record];
+							} else {
+								thread.trace.records.push(record);
+							}
 						}
 						// Continue with next instruction
 						scheduler.addThread(0, thread.pc + 1, thread, thread.badness);

--- a/test/Examples.tests.ts
+++ b/test/Examples.tests.ts
@@ -113,7 +113,7 @@ describe('whynot.js examples', () => {
 				const trace = traces[i];
 
 				// Combine the records found so far with those of this trace
-				const combinedHead = trace.records.concat(head);
+				const combinedHead = trace.records ? trace.records.concat(head) : head;
 
 				if (!trace.prefixes.length) {
 					// Beginning of trace reached, add full record string
@@ -310,7 +310,7 @@ describe('whynot.js examples', () => {
 				const trace = traces[i];
 
 				// Combine the records found so far with those of this trace
-				const combinedHead = trace.records.concat(head);
+				const combinedHead = trace.records ? trace.records.concat(head) : head;
 
 				if (!trace.prefixes.length) {
 					// Beginning of trace reached, add full record string
@@ -463,7 +463,7 @@ describe('whynot.js examples', () => {
 			//                                      0    1    2    3    4    5    6
 			//                                                     '--- Expect CG to start here
 			const firstRecord = (function findFirstRecord(trace: Trace): number {
-				if (trace.records.length) {
+				if (trace.records !== null) {
 					return trace.records[0];
 				}
 
@@ -512,7 +512,7 @@ describe('whynot.js examples', () => {
 			//                                      0    1    2    3    4    5    6
 			//                                                     '--- Expect CG to start here
 			const firstRecord = (function findFirstRecord(trace: Trace): number {
-				if (trace.records.length) {
+				if (trace.records !== null) {
 					return trace.records[0];
 				}
 

--- a/test/Trace.tests.ts
+++ b/test/Trace.tests.ts
@@ -10,7 +10,7 @@ describe('Trace', () => {
 		});
 
 		it('has no records', () => {
-			expect(trace.records.length).toBe(0);
+			expect(trace.records).toBe(null);
 		});
 
 		it('has no prefixes', () => {
@@ -21,7 +21,7 @@ describe('Trace', () => {
 			it('does not change the trace', () => {
 				trace.compact();
 
-				expect(trace.records.length).toBe(0);
+				expect(trace.records).toBe(null);
 				expect(trace.prefixes.length).toBe(0);
 			});
 		});
@@ -32,9 +32,9 @@ describe('Trace', () => {
 		let trace: Trace;
 		beforeEach(() => {
 			rootTrace = new Trace(1, PROGRAM_LENGTH, null, 0);
-			rootTrace.records.push('A');
+			rootTrace.records = ['A'];
 			trace = new Trace(4, PROGRAM_LENGTH, rootTrace, 1);
-			trace.records.push('B');
+			trace.records = ['B'];
 		});
 
 		it('has only its own record', () => {
@@ -68,7 +68,7 @@ describe('Trace', () => {
 		});
 
 		it('has no records', () => {
-			expect(trace.records.length).toBe(0);
+			expect(trace.records).toBe(null);
 		});
 
 		it('has a two prefixes', () => {
@@ -78,7 +78,7 @@ describe('Trace', () => {
 		describe('.compact()', () => {
 			it('does not change the trace', () => {
 				trace.compact();
-				expect(trace.records.length).toBe(0);
+				expect(trace.records).toBe(null);
 				expect(trace.prefixes.length).toBe(2);
 			});
 		});

--- a/test/Trace.tests.ts
+++ b/test/Trace.tests.ts
@@ -38,7 +38,7 @@ describe('Trace', () => {
 		});
 
 		it('has only its own record', () => {
-			expect(trace.records.length).toBe(1);
+			expect(trace.records!.length).toBe(1);
 		});
 
 		it('has a single prefix', () => {
@@ -80,6 +80,32 @@ describe('Trace', () => {
 				trace.compact();
 				expect(trace.records).toBe(null);
 				expect(trace.prefixes.length).toBe(2);
+			});
+		});
+	});
+
+	describe('Compacting multiple chained traces', () => {
+		let rootTrace: Trace;
+		let parentTrace: Trace;
+		let trace: Trace;
+		beforeEach(() => {
+			rootTrace = new Trace(1, PROGRAM_LENGTH, null, 0);
+			rootTrace.records = ['A'];
+			parentTrace = new Trace(2, PROGRAM_LENGTH, rootTrace, 1);
+			parentTrace.records = ['B'];
+			trace = new Trace(4, PROGRAM_LENGTH, parentTrace, 1);
+		});
+
+		describe('.compact()', () => {
+			it('correctly combines the traces', () => {
+				trace.compact();
+				parentTrace.compact();
+
+				expect(trace.records).toEqual(['A', 'B']);
+				expect(trace.prefixes.length).toBe(0);
+
+				expect(parentTrace.records).toEqual(['A', 'B']);
+				expect(parentTrace.prefixes.length).toBe(0);
 			});
 		});
 	});

--- a/test/VM.tests.ts
+++ b/test/VM.tests.ts
@@ -11,7 +11,7 @@ describe('VM', () => {
 	}
 
 	function flattenTrace(trace: Trace, records: number[] = [], flatTraces: number[][] = []) {
-		var combinedRecords = trace.records.concat(records);
+		var combinedRecords = trace.records === null ? records : trace.records.concat(records);
 		if (!trace.prefixes.length) {
 			flatTraces.push(combinedRecords);
 		} else {
@@ -156,14 +156,8 @@ describe('VM', () => {
 			debugger;
 			const leftResult = vmLeftBad.execute(createInput([]));
 			const rightResult = vmRightBad.execute(createInput([]));
-			expect(flattenTrace(leftResult.acceptingTraces[0])).toEqual([
-				['B'],
-				['A']
-			]);
-			expect(flattenTrace(rightResult.acceptingTraces[0])).toEqual([
-				['A'],
-				['B']
-			]);
+			expect(flattenTrace(leftResult.acceptingTraces[0])).toEqual([['B'], ['A']]);
+			expect(flattenTrace(rightResult.acceptingTraces[0])).toEqual([['A'], ['B']]);
 		});
 	});
 

--- a/test/VM.tests.ts
+++ b/test/VM.tests.ts
@@ -297,7 +297,7 @@ describe('VM', () => {
 			return result.acceptingTraces.reduce(function(max: number, trace: Trace) {
 				const maxDepthForTrace =
 					1 +
-					trace.records.reduce(function(max, result) {
+					trace.records!.reduce(function(max, result) {
 						const maxDepthForRecord = computeMaxDepth(result);
 						return Math.max(maxDepthForRecord, max);
 					}, 0);


### PR DESCRIPTION
This fixes #33 

The records property of Trace was always initialized to an empty array even if it was never used. By making the allocation lazy, the records property will be uninitialized until we add an element into the records array.