### PR TITLE
Replace visited instructions with ancestry sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,16 @@
 	"version": "1.0.0",
 	"description": "Generic VM-based structure matching framework",
 	"author": "Stef Busking <stef.busking@gmail.com>",
-	"contributors": ["Martin Middel <martinmiddel@gmail.com>"],
+	"contributors": [
+		"Martin Middel <martinmiddel@gmail.com>"
+	],
 	"license": "MIT",
-	"keywords": ["Language", "Matching", "Regex", "Structure"],
+	"keywords": [
+		"Language",
+		"Matching",
+		"Regex",
+		"Structure"
+	],
 	"main": "dist/whynot.js",
 	"module": "dist/whynot.mjs",
 	"scripts": {
@@ -17,7 +24,9 @@
 		"prepare": "npm run build:bundle",
 		"test": "jest --coverage --verbose"
 	},
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/bwrrp/whynot.js"
@@ -38,8 +47,17 @@
 			"^.+\\.(t|j)sx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
 		},
 		"testRegex": "(\\.(tests))\\.(tsx?|jsx?)$",
-		"moduleFileExtensions": ["ts", "tsx", "js", "json", "jsx"],
-		"collectCoverageFrom": ["src/**/*.ts"]
+		"testURL": "http://localhost",
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js",
+			"json",
+			"jsx"
+		],
+		"collectCoverageFrom": [
+			"src/**/*.ts"
+		]
 	},
 	"prettier": {
 		"printWidth": 100,

--- a/src/DisjointSet.ts
+++ b/src/DisjointSet.ts
@@ -1,0 +1,115 @@
+import * as assert from "assert";
+
+/**
+ * DisjointSet data structure.
+ */
+export default class DisjointSet {
+    private _parent: number[];
+    private _rank: number[];
+
+    /**
+     * Constructor for a DisjointSet, implementing a Union-Find algorithm with rank values.
+     * 
+     * @param count amount of elements. 
+     */
+    constructor(count: number) {
+        assert(count > 0);
+
+        this._parent = new Array(count);
+        this._rank = new Array(count);
+
+        this.makeSet();
+    }
+
+    /**
+     * The makeSet operation makes a new set by creating a new element with a unique id, a rank of 0, and a parent pointer to itself. 
+     * The parent pointer to itself indicates that the element is the representative member of its own set.
+     */
+    makeSet() {
+        for (var i = 0; i < this._parent.length; i++) {
+            this._parent[i] = i;
+            this._rank[i] = 0;
+        }
+    }
+
+    // Getter for parent property.
+    get parent(): number[] {
+        return this._parent;
+    }
+
+    // Getter for rank property.
+    get rank(): number[] {
+        return this._rank;
+    }
+
+    /**
+     * find(i) follows the chain of parent pointers from i up the tree until it reaches a root element, whose parent is itself. 
+     * This root element is the representative member of the set to which i belongs, and may be i itself.
+     * 
+     * @param i Element of which to find the root of.
+     */
+    find(i: number) {
+        assert(i >= 0);
+        assert(i < this._parent.length);
+
+        // If i is the parent itself, then i is the representative of its set.
+        if (this._parent[i] == i) {
+            return i;
+        }
+
+        // Else traverse to the root to find the represantative of its set.
+        var last = i;
+        while(this._parent[last] !== last) {
+            last = this._parent[last];
+        }
+
+        // Cache the result by moving i's node directly under the respresentative of its set.
+        // This is called 'path compression'.
+        while(this._parent[i] !== i) {
+            var t = this._parent[i];
+            this._parent[i] = last;
+            i = t;
+        } 
+
+        return last;
+    }
+
+    /**
+     * union(i,j) uses find(x) to determine the roots of the trees i and j belong to. 
+     * If the roots are distinct, the trees are combined by attaching the root of one to the root of the other. 
+     * If this is done naively, such as by always making i a child of j, the height of the trees can grow as O(n). 
+     * To prevent this union by rank is used.
+     * 
+     * @param i The first tree.
+     * @param j The second tree.
+     */
+    union(i: number, j: number) {
+        assert(i >= 0);
+        assert(i < this._parent.length);
+        assert(j >= 0);
+        assert(j < this._parent.length);
+
+        // Check if i and j are already in the same set, 
+        // in which case we don't have to do anything.
+        // This also means that we have found a cycle. 
+        var iRep = this.find(i);
+        var jRep = this.find(j);
+        if (iRep === jRep) {
+            return;
+        }
+
+        // If i and j are not in the same set, 
+        // we can merge the sets and set the new rank accordingly.
+        var iRank = this._rank[iRep];
+        var jRank = this._rank[jRep];
+        if (iRank < jRank) {
+            this._rank[iRep] = jRank;
+            this._rank[jRep] = iRank
+        }
+
+        this._parent[jRep] = iRep;
+        if (this._rank[iRep] === this._rank[jRep]) {
+            this._rank[iRep]++;
+        }
+    }
+}

--- a/src/DisjointSet.ts
+++ b/src/DisjointSet.ts
@@ -1,115 +1,104 @@
-import * as assert from "assert";
-
 /**
  * DisjointSet data structure.
  */
 export default class DisjointSet {
-    private _parent: number[];
-    private _rank: number[];
+	private _parent: number[];
+	private _rank: number[];
 
-    /**
-     * Constructor for a DisjointSet, implementing a Union-Find algorithm with rank values.
-     * 
-     * @param count amount of elements. 
-     */
-    constructor(count: number) {
-        assert(count > 0);
+	/**
+	 * Constructor for a DisjointSet, implementing a Union-Find algorithm with rank values.
+	 *
+	 * @param count amount of elements.
+	 */
+	constructor(count: number) {
+		this._parent = new Array(count);
+		this._rank = new Array(count);
 
-        this._parent = new Array(count);
-        this._rank = new Array(count);
+		this.makeSet();
+	}
 
-        this.makeSet();
-    }
+	/**
+	 * The makeSet operation makes a new set by creating a new element with a unique id, a rank of 0, and a parent pointer to itself.
+	 * The parent pointer to itself indicates that the element is the representative member of its own set.
+	 */
+	makeSet() {
+		for (let i = 0; i < this._parent.length; i++) {
+			this._parent[i] = i;
+			this._rank[i] = 0;
+		}
+	}
 
-    /**
-     * The makeSet operation makes a new set by creating a new element with a unique id, a rank of 0, and a parent pointer to itself. 
-     * The parent pointer to itself indicates that the element is the representative member of its own set.
-     */
-    makeSet() {
-        for (var i = 0; i < this._parent.length; i++) {
-            this._parent[i] = i;
-            this._rank[i] = 0;
-        }
-    }
+	// Getter for parent property.
+	get parent(): number[] {
+		return this._parent;
+	}
 
-    // Getter for parent property.
-    get parent(): number[] {
-        return this._parent;
-    }
+	// Getter for rank property.
+	get rank(): number[] {
+		return this._rank;
+	}
 
-    // Getter for rank property.
-    get rank(): number[] {
-        return this._rank;
-    }
+	/**
+	 * find(i) follows the chain of parent pointers from i up the tree until it reaches a root element, whose parent is itself.
+	 * This root element is the representative member of the set to which i belongs, and may be i itself.
+	 *
+	 * @param i Element of which to find the root of.
+	 */
+	find(i: number) {
+		// If i is the parent itself, then i is the representative of its set.
+		if (this._parent[i] == i) {
+			return i;
+		}
 
-    /**
-     * find(i) follows the chain of parent pointers from i up the tree until it reaches a root element, whose parent is itself. 
-     * This root element is the representative member of the set to which i belongs, and may be i itself.
-     * 
-     * @param i Element of which to find the root of.
-     */
-    find(i: number) {
-        assert(i >= 0);
-        assert(i < this._parent.length);
+		// Else traverse to the root to find the representative of its set.
+		let last = i;
+		while (this._parent[last] !== last) {
+			last = this._parent[last];
+		}
 
-        // If i is the parent itself, then i is the representative of its set.
-        if (this._parent[i] == i) {
-            return i;
-        }
+		// Cache the result by moving i's node directly under the respresentative of its set.
+		// This is called 'path compression'.
+		while (this._parent[i] !== i) {
+			const t = this._parent[i];
+			this._parent[i] = last;
+			i = t;
+		}
 
-        // Else traverse to the root to find the represantative of its set.
-        var last = i;
-        while(this._parent[last] !== last) {
-            last = this._parent[last];
-        }
+		return last;
+	}
 
-        // Cache the result by moving i's node directly under the respresentative of its set.
-        // This is called 'path compression'.
-        while(this._parent[i] !== i) {
-            var t = this._parent[i];
-            this._parent[i] = last;
-            i = t;
-        } 
+	/**
+	 * union(i,j) uses find(x) to determine the roots of the trees i and j belong to.
+	 * If the roots are distinct, the trees are combined by attaching the root of one to the root of the other.
+	 * If this is done naively, such as by always making i a child of j, the height of the trees can grow as O(n).
+	 * To prevent this union by rank is used.
+	 *
+	 * @param i The first tree.
+	 * @param j The second tree.
+	 */
+	union(i: number, j: number) {
+		// Check if i and j are already in the same set,
+		// in which case we don't have to do anything.
+		// This also means that we have found a cycle.
+		const iRep = this.find(i);
+		const jRep = this.find(j);
+		if (iRep === jRep) {
+			return;
+		}
 
-        return last;
-    }
+		// If i and j are not in the same set,
+		// we can merge the sets and set the new rank accordingly.
+		const iRank = this._rank[iRep];
+		const jRank = this._rank[jRep];
+		if (iRank < jRank) {
+			this._rank[iRep] = jRank;
+			this._rank[jRep] = iRank
+		}
+		this._parent[jRep] = iRep;
 
-    /**
-     * union(i,j) uses find(x) to determine the roots of the trees i and j belong to. 
-     * If the roots are distinct, the trees are combined by attaching the root of one to the root of the other. 
-     * If this is done naively, such as by always making i a child of j, the height of the trees can grow as O(n). 
-     * To prevent this union by rank is used.
-     * 
-     * @param i The first tree.
-     * @param j The second tree.
-     */
-    union(i: number, j: number) {
-        assert(i >= 0);
-        assert(i < this._parent.length);
-        assert(j >= 0);
-        assert(j < this._parent.length);
-
-        // Check if i and j are already in the same set, 
-        // in which case we don't have to do anything.
-        // This also means that we have found a cycle. 
-        var iRep = this.find(i);
-        var jRep = this.find(j);
-        if (iRep === jRep) {
-            return;
-        }
-
-        // If i and j are not in the same set, 
-        // we can merge the sets and set the new rank accordingly.
-        var iRank = this._rank[iRep];
-        var jRank = this._rank[jRep];
-        if (iRank < jRank) {
-            this._rank[iRep] = jRank;
-            this._rank[jRep] = iRank
-        }
-
-        this._parent[jRep] = iRep;
-        if (this._rank[iRep] === this._rank[jRep]) {
-            this._rank[iRep]++;
-        }
-    }
+		// If the rank is the same, increment the rank.
+		if (this._rank[iRep] === this._rank[jRep]) {
+			this._rank[iRep]++;
+		}
+	}
 }

--- a/src/Thread.ts
+++ b/src/Thread.ts
@@ -7,51 +7,58 @@ export default class Thread {
 	public pc!: number;
 	public trace!: Trace;
 	public badness!: number;
+	public threadId!: number;
 
 	private _generationNumber!: number;
 
 	/**
 	 * @param pc               Program counter for the scheduled instruction
-	 * @param programLength    Length of the current program
 	 * @param parentThread     The thread that spawned this thread
-	 * @param badness          Increasing badness decreases thread priority
 	 * @param generationNumber The index of the genaration this Thread is running in
+	 * @param threadId         Id of a thread
+	 * @param badness          Increasing badness decreases thread priority
 	 */
 	constructor(
 		pc: number,
-		programLength: number,
 		parentThread: Thread | undefined,
-		badness: number = 0,
-		generationNumber: number
+		generationNumber: number,
+		threadId: number,
+		badness: number = 0
 	) {
-		this.initialize(pc, programLength, parentThread, badness, generationNumber);
+		this.initialize(pc, parentThread, generationNumber, threadId, badness);
 	}
 
 	/**
 	 * (re)initialize the Thread object with the specified values
 	 *
 	 * @param pc               Program counter for the scheduled instruction
-	 * @param programLength    Length of the current program
 	 * @param parentThread     The thread that spawned this thread
-	 * @param badness          Increasing badness decreases thread priority
 	 * @param generationNumber The index of the genaration this Thread is running in
+	 * @param threadId         Id of a thread
+	 * @param badness          Increasing badness decreases thread priority
 	 */
 	initialize(
 		pc: number,
-		programLength: number,
 		parentThread: Thread | undefined,
-		badness: number = 0,
-		generationNumber: number
+		generationNumber: number,
+		threadId: number,
+		badness: number = 0
 	) {
 		this.pc = pc;
 
 		const prefixTrace = parentThread ? parentThread.trace : null;
-		this.trace = new Trace(pc, programLength, prefixTrace, generationNumber);
+		this.trace = new Trace(prefixTrace);
 
 		this.badness = badness || 0;
 
 		this._generationNumber = generationNumber;
+		this.threadId = threadId;
 	}
+
+	// Getter for generationNumber property.
+    get generationNumber(): number {
+        return this._generationNumber;
+    }
 
 	/**
 	 * Another thread joins the current, combine traces and badness.
@@ -71,5 +78,14 @@ export default class Thread {
 	 */
 	compact() {
 		this.trace.compact();
+	}
+
+	/**
+	 * Update the badness.
+	 * 
+	 * @param badness Number of badness
+	 */
+	updateBadness(badness: number) {
+		this.badness = Math.max(this.badness, badness);
 	}
 }

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -1,54 +1,22 @@
-function mergeVisitedInstructions(
-	targetVisitedInstructions: number[],
-	otherVisitedInstructions: number[],
-	programLength: number
-) {
-	for (let i = 0; i < programLength; ++i) {
-		const ourGeneration = targetVisitedInstructions[i];
-		const otherGeneration = otherVisitedInstructions[i];
-
-		if (ourGeneration === undefined) {
-			targetVisitedInstructions[i] = otherGeneration;
-		} else if (otherGeneration !== undefined) {
-			targetVisitedInstructions[i] = Math.max(ourGeneration, otherGeneration);
-		}
-	}
-}
-
 /**
  * A Trace represents the execution history of a Thread
  */
 export default class Trace {
+
 	public records: any[] = [];
 	public prefixes: Trace[] = [];
 
-	private _descendants: Trace[] = [];
 	private _isCompacted: boolean = false;
-	private _programLength: number;
-	private _visitedInstructions: number[];
 
 	/**
-	 * @param pc               Program counter for the scheduled instruction
-	 * @param programLength    Length of the current program
 	 * @param precedingTrace   The trace to append this trace to
-	 * @param generationNumber The index of the genaration this Trace's Thread is running in
 	 */
 	constructor(
-		pc: number,
-		programLength: number,
-		precedingTrace: Trace | null,
-		generationNumber: number
+		precedingTrace: Trace | null
 	) {
-		this._programLength = programLength;
-
 		if (precedingTrace) {
 			this.prefixes.push(precedingTrace);
-			precedingTrace._descendants.push(this);
-			this._visitedInstructions = precedingTrace._visitedInstructions.slice(0);
-		} else {
-			this._visitedInstructions = new Array(programLength);
 		}
-		this._visitedInstructions[pc] = generationNumber;
 	}
 
 	/**
@@ -62,36 +30,6 @@ export default class Trace {
 	join(prefixTrace: Trace) {
 		this.prefixes.push(prefixTrace);
 		this._isCompacted = false;
-
-		(function mergeVisitedInstructionsIntoTrace(trace: Trace) {
-			// Merge prefixTrace's set of visited instructions into our own
-			mergeVisitedInstructions(
-				trace._visitedInstructions,
-				prefixTrace._visitedInstructions,
-				trace._programLength
-			);
-			// Do the same for the descendants
-			for (let i = 0, l = trace._descendants.length; i < l; ++i) {
-				mergeVisitedInstructionsIntoTrace(trace._descendants[i]);
-			}
-		})(this);
-	}
-
-	/**
-	 * Returns whether the Trace has visited the specified instruction, in the given generation.
-	 *
-	 * If no generation is given, it is tested if the trace has passed the instruction at all.
-	 *
-	 * @param pc         Program counter for the instruction to test
-	 * @param generation The index of the generation to test for
-	 *
-	 * @return Whether the trace has visited the instruction
-	 */
-	contains(pc: number, generation?: number): boolean {
-		if (generation === undefined) {
-			return this._visitedInstructions[pc] !== undefined;
-		}
-		return this._visitedInstructions[pc] === generation;
 	}
 
 	/**

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -19,7 +19,6 @@ function mergeVisitedInstructions(
  * A Trace represents the execution history of a Thread
  */
 export default class Trace {
-	public head: number[] = [];
 	public records: any[] = [];
 	public prefixes: Trace[] = [];
 
@@ -40,7 +39,6 @@ export default class Trace {
 		precedingTrace: Trace | null,
 		generationNumber: number
 	) {
-		this.head = [pc];
 		this._programLength = programLength;
 
 		if (precedingTrace) {
@@ -108,8 +106,6 @@ export default class Trace {
 		while (trace.prefixes.length === 1) {
 			// Trace has a single prefix, combine traces
 			const prefix = trace.prefixes[0];
-			// Combine heads
-			this.head.unshift.apply(this.head, prefix.head);
 			// Combine records
 			this.records.unshift.apply(this.records, prefix.records);
 			// Adopt prefixes

--- a/test/DisjointSet.tests.ts
+++ b/test/DisjointSet.tests.ts
@@ -1,0 +1,44 @@
+import DisjointSet from "../src/DisjointSet";
+
+describe ('DisjointSet', () => {
+    describe('MakeSet', () => {
+        it('Parent array is initialized', () => {
+            let disjointSet = new DisjointSet(7);
+            expect(disjointSet.parent.length).toBe(7);
+            expect(disjointSet.parent).toEqual([0, 1, 2, 3, 4, 5, 6]);
+        });
+        
+        it('Rank array is initialized', () => {
+            let disjointSet = new DisjointSet(7);
+            expect(disjointSet.rank.length).toBe(7);
+            expect(disjointSet.rank).toEqual([0, 0, 0, 0, 0, 0, 0]);
+        });
+    });
+
+    describe('Union and Find', () => {
+        it('Element is the parent itself', () => {
+            let disjointSet = new DisjointSet(7);
+            expect(disjointSet.find(2)).toBe(2);
+        });
+
+        it('Union of 2 nodes', () => {
+            let disjointSet = new DisjointSet(7);
+            disjointSet.union(1, 2);
+            expect(disjointSet.find(2)).toBe(1);
+        });
+
+        it('Finding a cycle', () => {
+            let disjointSet = new DisjointSet(7);
+            disjointSet.union(1, 2);
+            disjointSet.union(1, 2);
+            expect(disjointSet.find(2)).toBe(1);
+        });
+
+        it('Different ranks', () => {
+            let disjointSet = new DisjointSet(7);
+            disjointSet.union(1, 2);
+            disjointSet.union(0, 1);
+            expect(disjointSet.rank[0]).toBe(1);
+        })
+    });
+})

--- a/test/Examples.tests.ts
+++ b/test/Examples.tests.ts
@@ -329,7 +329,7 @@ describe('whynot.js examples', () => {
 			// returns any traces, these represent how the program was able to match the input. If
 			// it doesn't, the input did not match in any way.
 			const vm = compileRegexVM('(a|b)*', false);
-
+			
 			// This regex should match the string 'a', and generate extensions '[a]a[a]', '[b]a[a]',
 			// '[a]a[b]', '[b]a[b]'
 			const matchingResult = vm.execute(createInput('a'));

--- a/test/Generation.tests.ts
+++ b/test/Generation.tests.ts
@@ -29,6 +29,25 @@ describe('Generation', () => {
 				const nextThread = generation.getNextThread();
 				expect(nextThread).toBe(addedThread);
 			});
+
+			it('pc out of bounds', () => {
+				generation.addThread(217389);
+				const nextThread = generation.getNextThread();
+				expect(nextThread).toBeInstanceOf(Thread);
+			});
+
+			it('parentThread is undefined', () => {
+				generation.addThread(0, undefined);
+				const nextThread = generation.getNextThread();
+				expect(nextThread).toBeInstanceOf(Thread);
+			});
+
+			it('incorrect generation number', () => {
+				const parentThread = new Thread(0, undefined, 56756, 0, 0);
+				generation.addThread(0, parentThread);
+				const nextThread = generation.getNextThread();
+				expect(nextThread).toBeInstanceOf(Thread);
+			});
 		});
 
 		describe('duplicate', () => {

--- a/test/Result.tests.ts
+++ b/test/Result.tests.ts
@@ -3,14 +3,14 @@ import Trace from '../src/Trace';
 
 describe('Result', () => {
 	it('can be successful', () => {
-		var result = new Result([new Trace(0, 0, null, 0)], []);
+		const result = new Result([new Trace(null)], []);
 		expect(result.success).toBe(true);
 		expect(result.acceptingTraces.length).toBe(1);
 		expect(result.failingTraces.length).toBe(0);
 	});
 
 	it('can be unsuccessful', () => {
-		var result = new Result([], [new Trace(0, 0, null, 0)]);
+		const result = new Result([], [new Trace(null)]);
 		expect(result.success).toBe(false);
 		expect(result.acceptingTraces.length).toBe(0);
 		expect(result.failingTraces.length).toBe(1);

--- a/test/Scheduler.tests.ts
+++ b/test/Scheduler.tests.ts
@@ -1,5 +1,4 @@
 import Scheduler from '../src/Scheduler';
-import Thread from '../src/Thread';
 
 describe('Scheduler', () => {
 	let scheduler: Scheduler;
@@ -32,9 +31,13 @@ describe('Scheduler', () => {
 
 			scheduler.nextGeneration();
 
-			var nextGenThread = scheduler.getNextThread();
+			const nextGenThread = scheduler.getNextThread();
 			expect(nextGenThread).toBe(rootThread);
 			expect(scheduler.getNextThread()).toBe(null);
 		});
+
+		it('Throw an error for incorrect generationNumber', () => {
+			expect(function() {scheduler.addThread(2183, 3, undefined, 123);}).toThrow();
+		})
 	});
 });

--- a/test/Thread.tests.ts
+++ b/test/Thread.tests.ts
@@ -1,12 +1,12 @@
 import Thread from '../src/Thread';
 
-const PROGRAM_LENGTH = 10;
+const expectedThreadId = 456;
 
 describe('Thread', () => {
 	describe('no preceding thread', () => {
 		let thread: Thread;
 		beforeEach(() => {
-			thread = new Thread(4, PROGRAM_LENGTH, undefined, 123, 0);
+			thread = new Thread(4, undefined, 0, expectedThreadId, 123);
 		});
 
 		it('has a program counter', () => {
@@ -26,8 +26,8 @@ describe('Thread', () => {
 		let rootThread: Thread;
 		let thread: Thread;
 		beforeEach(() => {
-			rootThread = new Thread(1, PROGRAM_LENGTH, undefined, 123, 0);
-			thread = new Thread(4, PROGRAM_LENGTH, rootThread, 456, 1);
+			rootThread = new Thread(1, undefined, 0, expectedThreadId, 123);
+			thread = new Thread(4, rootThread, 1, expectedThreadId, 456);
 		});
 
 		it('has a program counter', () => {
@@ -48,9 +48,9 @@ describe('Thread', () => {
 		let otherRootThread: Thread;
 		let thread: Thread;
 		beforeEach(() => {
-			rootThread = new Thread(1, PROGRAM_LENGTH, undefined, 123, 0);
-			otherRootThread = new Thread(2, PROGRAM_LENGTH, undefined, 234, 0);
-			thread = new Thread(4, PROGRAM_LENGTH, rootThread, 456, 1);
+			rootThread = new Thread(1, undefined, 0, expectedThreadId, 123);
+			otherRootThread = new Thread(2, undefined, 0, expectedThreadId, 234);
+			thread = new Thread(4, rootThread, 1, expectedThreadId, 456);
 
 			thread.join(otherRootThread, 789);
 		});
@@ -67,4 +67,31 @@ describe('Thread', () => {
 			expect(thread.trace.prefixes.length).toBe(2);
 		});
 	});
+
+	describe('defaults', () => {
+		let rootThread: Thread;
+		let otherRootThread: Thread;
+		let thread: Thread;
+
+		it('default badness', () => {
+			rootThread = new Thread(1, undefined, 0, expectedThreadId);
+			otherRootThread = new Thread(2, undefined, 0, expectedThreadId);
+			thread = new Thread(4, rootThread, 1, expectedThreadId);
+
+			thread.join(otherRootThread);
+			expect(thread.badness).toBe(0);
+		});
+
+		it('default join', () => {
+			thread = new Thread(4, rootThread, 1, expectedThreadId);
+			thread.join();
+			expect(thread.badness).toBe(0);
+		});
+
+		it('reinitialize thread with default badness', () => {
+			thread = new Thread(4, rootThread, 1, expectedThreadId);
+			thread.initialize(4, rootThread, 1, expectedThreadId);
+			expect(thread.badness).toBe(0);
+		}) 
+	})
 });

--- a/test/Trace.tests.ts
+++ b/test/Trace.tests.ts
@@ -9,10 +9,6 @@ describe('Trace', () => {
 			trace = new Trace(4, PROGRAM_LENGTH, null, 0);
 		});
 
-		it('has a head', () => {
-			expect(trace.head).toEqual([4]);
-		});
-
 		it('has no records', () => {
 			expect(trace.records.length).toBe(0);
 		});
@@ -25,7 +21,6 @@ describe('Trace', () => {
 			it('does not change the trace', () => {
 				trace.compact();
 
-				expect(trace.head).toEqual([4]);
 				expect(trace.records.length).toBe(0);
 				expect(trace.prefixes.length).toBe(0);
 			});
@@ -40,24 +35,18 @@ describe('Trace', () => {
 			trace = new Trace(4, PROGRAM_LENGTH, rootTrace, 1);
 		});
 
-		it('has a head', () => {
-			expect(trace.head).toEqual([4]);
-		});
-
 		it('has no records', () => {
 			expect(trace.records.length).toBe(0);
 		});
 
 		it('has a single prefix', () => {
 			expect(trace.prefixes.length).toBe(1);
-			expect(trace.prefixes[0].head).toEqual([1]);
 		});
 
 		describe('.compact()', () => {
 			it('combines the traces', () => {
 				trace.compact();
 
-				expect(trace.head).toEqual([1, 4]);
 				expect(trace.records.length).toBe(0);
 				expect(trace.prefixes.length).toBe(0);
 			});
@@ -71,7 +60,6 @@ describe('Trace', () => {
 				it('combines the traces', () => {
 					trace.compact();
 
-					expect(trace.head).toEqual([1, 4]);
 					expect(trace.records).toEqual(['bla', 'meep']);
 					expect(trace.prefixes.length).toBe(0);
 				});
@@ -91,25 +79,17 @@ describe('Trace', () => {
 			trace.prefixes.push(otherRootTrace);
 		});
 
-		it('has a head', () => {
-			expect(trace.head).toEqual([4]);
-		});
-
 		it('has no records', () => {
 			expect(trace.records.length).toBe(0);
 		});
 
 		it('has a two prefixes', () => {
 			expect(trace.prefixes.length).toBe(2);
-			expect(trace.prefixes[0].head).toEqual([1]);
-			expect(trace.prefixes[1].head).toEqual([2]);
 		});
 
 		describe('.compact()', () => {
 			it('does not change the trace', () => {
 				trace.compact();
-
-				expect(trace.head).toEqual([4]);
 				expect(trace.records.length).toBe(0);
 				expect(trace.prefixes.length).toBe(2);
 			});

--- a/test/Trace.tests.ts
+++ b/test/Trace.tests.ts
@@ -6,7 +6,7 @@ describe('Trace', () => {
 	describe('no preceding trace', () => {
 		let trace: Trace;
 		beforeEach(() => {
-			trace = new Trace(4, PROGRAM_LENGTH, null, 0);
+			trace = new Trace(null);
 		});
 
 		it('has no records', () => {
@@ -31,8 +31,8 @@ describe('Trace', () => {
 		let rootTrace: Trace;
 		let trace: Trace;
 		beforeEach(() => {
-			rootTrace = new Trace(1, PROGRAM_LENGTH, null, 0);
-			trace = new Trace(4, PROGRAM_LENGTH, rootTrace, 1);
+			rootTrace = new Trace(null);
+			trace = new Trace(rootTrace);
 		});
 
 		it('has no records', () => {
@@ -72,9 +72,9 @@ describe('Trace', () => {
 		let otherRootTrace: Trace;
 		let trace: Trace;
 		beforeEach(() => {
-			rootTrace = new Trace(1, PROGRAM_LENGTH, null, 0);
-			otherRootTrace = new Trace(2, PROGRAM_LENGTH, null, 0);
-			trace = new Trace(4, PROGRAM_LENGTH, rootTrace, 1);
+			rootTrace = new Trace(null);
+			otherRootTrace = new Trace(null);
+			trace = new Trace(rootTrace);
 
 			trace.prefixes.push(otherRootTrace);
 		});
@@ -93,54 +93,6 @@ describe('Trace', () => {
 				expect(trace.records.length).toBe(0);
 				expect(trace.prefixes.length).toBe(2);
 			});
-		});
-	});
-
-	describe('querying', () => {
-		let rootTrace1: Trace;
-		let rootTrace2: Trace;
-		let trace1: Trace;
-		let trace2: Trace;
-		beforeEach(() => {
-			rootTrace1 = new Trace(1, PROGRAM_LENGTH, null, 0);
-			rootTrace2 = new Trace(2, PROGRAM_LENGTH, null, 1);
-			trace1 = new Trace(3, PROGRAM_LENGTH, rootTrace1, 1);
-			trace2 = new Trace(1, PROGRAM_LENGTH, rootTrace2, 1);
-		});
-
-		it('can check whether a trace visited an instruction in any generation', () => {
-			expect(trace1.contains(1)).toBe(true);
-			expect(trace1.contains(2)).toBe(false);
-			expect(trace1.contains(3)).toBe(true);
-		});
-
-		it('can check whether a trace visited an instruction in a specific generation', () => {
-			expect(trace1.contains(1, 0)).toBe(true);
-			expect(trace1.contains(1, 1)).toBe(false);
-			expect(trace1.contains(2, 0)).toBe(false);
-			expect(trace1.contains(2, 1)).toBe(false);
-			expect(trace1.contains(3, 0)).toBe(false);
-			expect(trace1.contains(3, 1)).toBe(true);
-		});
-
-		it('checks all prefixes, considering the most recent generation only', () => {
-			trace1.join(trace2);
-			expect(trace1.contains(1, 0)).toBe(false);
-			expect(trace1.contains(1, 1)).toBe(true);
-			expect(trace1.contains(2, 0)).toBe(false);
-			expect(trace1.contains(2, 1)).toBe(true);
-			expect(trace1.contains(3, 0)).toBe(false);
-			expect(trace1.contains(3, 1)).toBe(true);
-		});
-
-		it('also updates descendant traces when a prefix is merged', () => {
-			rootTrace1.join(rootTrace2);
-			expect(trace1.contains(1, 0)).toBe(true);
-			expect(trace1.contains(1, 1)).toBe(false);
-			expect(trace1.contains(2, 0)).toBe(false);
-			expect(trace1.contains(2, 1)).toBe(true);
-			expect(trace1.contains(3, 0)).toBe(false);
-			expect(trace1.contains(3, 1)).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
This fixed #34.

This is a implementation to detect cycles in a graph by using a Union-Find algorithm with a Disjoint Set. 
Also, the test coverage is now 100%.