### PR TITLE
Clear threads before they are put in the oldThreadsList

### DIFF
--- a/src/Generation.ts
+++ b/src/Generation.ts
@@ -72,7 +72,7 @@ export default class Generation {
 		let i, l;
 		for (i = 0, l = this._threadList.length; i < l; ++i) {
 			const thread = this._threadList[i];
-			thread.compact();
+			thread.clear();
 			this._oldThreads.push(thread);
 		}
 		this._threadList.length = 0;

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -7,6 +7,9 @@ export default class Result {
 	public success: boolean;
 
 	constructor(public acceptingTraces: Trace[], public failingTraces: Trace[]) {
-		this.success = !!acceptingTraces.length;
+		this.success = acceptingTraces.length > 0;
+
+		this.acceptingTraces.forEach(trace => trace.compact());
+		this.failingTraces.forEach(trace => trace.compact());
 	}
 }

--- a/src/Thread.ts
+++ b/src/Thread.ts
@@ -72,4 +72,8 @@ export default class Thread {
 	compact() {
 		this.trace.compact();
 	}
+
+	clear() {
+		(this.trace as any) = null;
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"compilerOptions": {
 		"outDir": "lib",
-		"sourceMap": true,
 		"inlineSourceMap": true,
 		"strict": true,
 		"module": "commonjs",


### PR DESCRIPTION
As the Trace of a Thread is recreated when the Thread is recycled, it
is better to clear the reference to the old Trace when a Thread is put
in the oldThreadsList. This allows the garbage collector to claim the
old Trace.

Additionally, we should not compact these traces, as only the last set
will actually be returned to the caller. Instead, Result now compacts
only the accepting and failing traces at the end of the run.